### PR TITLE
Add CI and CD to uff repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, ubuntu-latest]
+        os: [macos-10.15, ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-latest]
+        os: [macos-11, ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,31 +4,6 @@ on:
   push
 
 jobs:
-  build_with_cmake:
-    name: build with cmake
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest]
-    
-    steps:
-    - uses: actions/checkout@v3
-    
-    - name: Install dependencies
-      run: | 
-        sudo apt-get install gfortran -y
-        sudo apt-get install python3-pip -y
-        pip install pybind11
-
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF -DCMAKE_INSTALL_PREFIX=/home/runner/work/
-
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build  
-    
-    - name: Install
-      run: cd build && make install
-  
   build_with_python:
     name: build with python
     runs-on: ${{ matrix.os }}
@@ -43,7 +18,7 @@ jobs:
         python-version: ${{matrix.python-version}}
     
     - name: Install dependencies
-      run: pip install -r requirements.txt
+      run: pip3 install -r requirements.txt
     
     - name: Install
       run: python3 setup.py install --user

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,7 @@
-name: CMake - Build
+name: Build with CMake and Python
 
 on:
-  push:
-    branches: [ "main", "ft-ci" ]
-  pull_request:
-    branches: [ "main" ]
+  push
 
 jobs:
   build_with_cmake:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, ubuntu-latest]
+        os: [macos-12, ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-10.15, ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,10 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Install dependencies
-      run: sudo apt-get install gfortran 
-      
+      run: | 
+        sudo apt-get install gfortran -y
+        sudo apt-get install python3-pip -y
+        pip install pybind11
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF -DCMAKE_INSTALL_PREFIX=/home/runner/work/

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Install depenencies
-      run: apt-get install gfortran 
+      run: sudo apt-get install gfortran 
       
 
     - name: Configure CMake

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,7 @@ jobs:
       
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF -CMAKE_BUILD_PREFIX=/home/runner/work/
+      run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF -DCMAKE_BUILD_PREFIX=/home/runner/work/
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build  

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: action/checkout@v3
+    - uses: actions/checkout@v3
     
     - name: Install dependencies
       run: pip install -r requierements.txt

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,7 @@ jobs:
       
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF
+      run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF -CMAKE_BUILD_PREFIX=${{github.workspace}}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build  

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,7 @@ jobs:
       
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF -CMAKE_BUILD_PREFIX=${{github.workspace}}
+      run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF -CMAKE_BUILD_PREFIX=/usr/local/lib/
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build  

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
       run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --config  
+      run: cmake --build ${{github.workspace}}/build  
     
     - name: Install
       run: make install

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,5 +38,5 @@ jobs:
       run: pip install -r requirements.txt
     
     - name: Install
-      run: python3 setup.py install
+      run: python3 setup.py install --user
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,28 @@
+name: CMake - Build
+
+on:
+  push:
+    branches: [ "main", "ft-ci" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Install depenencies
+      run: apt-get install gfortran 
+      
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config  
+    
+    - name: Install
+      run: make install
+

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Install dependencies
-      run: pip install -r requierements.txt
+      run: pip install -r requirements.txt
     
     - name: Install
       run: python3 setup.py install

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,7 @@ jobs:
       
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF -DCMAKE_BUILD_PREFIX=/home/runner/work/
+      run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF -DCMAKE_INSTALL_PREFIX=/home/runner/work/
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build  

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,8 +9,11 @@ on:
 jobs:
   build_with_cmake:
     name: build with cmake
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    
     steps:
     - uses: actions/checkout@v3
     
@@ -29,14 +32,21 @@ jobs:
   
   build_with_python:
     name: build with python
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     
     steps:
     - uses: actions/checkout@v3
+      with: 
+        python-version: ${{matrix.python-version}}
     
     - name: Install dependencies
       run: pip install -r requirements.txt
     
     - name: Install
       run: python3 setup.py install --user
+      
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,13 +7,14 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  build_with_cmake:
+    name: build with cmake
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
     
-    - name: Install depenencies
+    - name: Install dependencies
       run: sudo apt-get install gfortran 
       
 
@@ -25,4 +26,17 @@ jobs:
     
     - name: Install
       run: cd build && make install
+  
+  build_with_python:
+    name: build with python
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: action/checkout@v3
+    
+    - name: Install dependencies
+      run: pip install -r requierements.txt
+    
+    - name: Install
+      run: python3 setup.py install
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,7 @@ jobs:
       
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF -CMAKE_BUILD_PREFIX=/usr/local/lib/
+      run: cmake -B ${{github.workspace}}/build -DBUILD_EXAMPLES=OFF -DBUILD_FORTRAN_MODULE=OFF -CMAKE_BUILD_PREFIX=/home/runner/work/
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build  

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,5 +24,5 @@ jobs:
       run: cmake --build ${{github.workspace}}/build  
     
     - name: Install
-      run: make install
+      run: cd build && make install
 

--- a/.github/workflows/upload_wheels.yml
+++ b/.github/workflows/upload_wheels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.9, ubuntu-latest]
+        os: [macos-10.15, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/upload_wheels.yml
+++ b/.github/workflows/upload_wheels.yml
@@ -1,0 +1,38 @@
+name: build full and pypi upload
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  wheel_build_full:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: build wheels
+      uses: pypa/cibuildwheel@v2.11.1
+
+    - uses: actions/upload-artifact@v3
+      with:
+        path: ./wheelhouse/*.whl
+
+  upload_pypi:
+    needs: [wheel_build_full]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@1.6.1
+        with:
+          skip_existing: true
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/upload_wheels.yml
+++ b/.github/workflows/upload_wheels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-10.9, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/upload_wheels.yml
+++ b/.github/workflows/upload_wheels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ test-extras = ["test"]
 before-build = "rm -rf {project}/build"
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64"]
+archs = ["x86_64", "arm64"]
+test-skip = ["*arm64"]
 build = ["cp*"]
 
 [tool.cibuildwheel.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,17 @@ requires = [
 ]
 
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+test-command = "pytest {project}/tests"
+test-extras = ["test"]
+before-build = "rm -rf {project}/build"
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+test-skip = ["*arm64"]
+build = ["cp*"]
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64"]
+build = ["cp*-many*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ test-extras = ["test"]
 before-build = "rm -rf {project}/build"
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]
-test-skip = ["*arm64"]
+archs = ["x86_64"]
 build = ["cp*"]
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
Add github actions to the repository for CI and CD.
Currently there are not tests for `uff`, so the CI is successful, if `uff` can build without problems. This happens at every push to a repository.
When a push on the main branch happens, the CD is triggered and wheels of different python versions and OS (macOS and ubuntu) are created and uploaded to PyPI. 